### PR TITLE
Exclude PotentialNamespace while comparing layer features

### DIFF
--- a/ancestry.go
+++ b/ancestry.go
@@ -101,12 +101,12 @@ func (b *AncestryBuilder) addLayerFeatures(detector database.Detector, features 
 	}
 
 	existingFeatures := b.features[detector]
-	currentFeatures := make([]layerIndexedFeature, 0, len(features))
+	currentFeatures := make([]layerIndexedFeature, 0, len(features)+len(existingFeatures))
 	// Features that are not in the current layer should be removed.
 	for i := range existingFeatures {
 		feature := existingFeatures[i]
 		for j := range features {
-			if features[j] == *feature.Feature {
+			if features[j].CompareWithoutNamespace(*feature.Feature) {
 				currentFeatures = append(currentFeatures, feature)
 				break
 			}

--- a/database/layer.go
+++ b/database/layer.go
@@ -63,3 +63,11 @@ type LayerFeature struct {
 	By                 Detector  `json:"by"`
 	PotentialNamespace Namespace `json:"potentialNamespace"`
 }
+
+// CompareWithoutNamespace - compares Features and exclude PotentialNamespace
+func (l *LayerFeature) CompareWithoutNamespace(other LayerFeature) bool {
+	if l.Feature == other.Feature && l.By == other.By {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
PotentialNamespace needs to be excluded from comparison in
addLayerFeatures, because otherwise some features can be lost in higher
layer.