### PR TITLE
Filter out duplicated RPMs in higher layers.

### DIFF
--- a/ancestry.go
+++ b/ancestry.go
@@ -117,7 +117,7 @@ func (b *AncestryBuilder) addLayerFeatures(detector database.Detector, features 
 	for i := range features {
 		found := false
 		for j := range existingFeatures {
-			if *existingFeatures[j].Feature == features[i] {
+			if existingFeatures[j].Feature.Feature == features[i].Feature {
 				found = true
 				break
 			}


### PR DESCRIPTION
Packages will be shown only in layers where they were installed or
updated. The previous implementation was causing a false positives.

Example:
Base layer:
    - python-setuptools - rhel7
Other layer:
    - python-setuptools - openshift3

The package was installed in base layer so it should have only rhel7
namespace, but since feature scanner always returns all packages
installed from base layer up to current layer it can cause false
positives.