### PR TITLE
Fix Red Hat security updater

### DIFF
--- a/ext/featurefmt/redhat/redhat.go
+++ b/ext/featurefmt/redhat/redhat.go
@@ -253,8 +253,11 @@ func getPotentialNamespace(files tarutil.FilesMap) (namespaces []database.Namesp
 		previousNVR = ""
 		previousArch = ""
 	}
-
+	if nvr == "" || arch == ""{
+		return
+	}
 	cpes := getCPEs(nvr, arch)
+	log.WithField("cpes", cpes).Debug("Found CPEs for given layer")
 	fmt.Println(cpes)
 	for _, cpe := range cpes {
 		namespace := database.Namespace{


### PR DESCRIPTION
VMaaS releases new data updates every 6 hours which can lead to lost
advisories with the old Red Hat updater. This commit changes the way how
updater selects VMaaS data in incremental updates.

Advisories are fetched by issued date and compared with what we already
have in database.