### PR TITLE
Include advisory name to CVE name

### DIFF
--- a/ext/vulnsrc/redhat/redhat.go
+++ b/ext/vulnsrc/redhat/redhat.go
@@ -382,10 +382,10 @@ func parseAdvisory(advisory Advisory, cpeMapping []CpeMapping) (vulnerabilities 
 		packageMap := make(map[string]bool)
 		vulnerability := database.VulnerabilityWithAffected{
 			Vulnerability: database.Vulnerability{
-				Name:        cve,
+				Name:        cve + " - " + advisory.Name,
 				Link:        cveURL + cve,
 				Severity:    severity(advisory.Severity),
-				Description: advisory.Name + " - " + advisory.Description,
+				Description: advisory.Description,
 			},
 		}
 		for _, nevra := range advisory.PackageList {

--- a/ext/vulnsrc/redhat/redhat_test.go
+++ b/ext/vulnsrc/redhat/redhat_test.go
@@ -52,10 +52,10 @@ func TestRedHatParserOneCVE(t *testing.T) {
 	rpmToSrpmMapping = mockRpmToSrpm
 	vulnerabilities := parseAdvisory(adv, cpeMapping)
 	fmt.Println(vulnerabilities)
-	assert.Equal(t, "CVE-2017-2582", vulnerabilities[0].Name)
+	assert.Equal(t, "CVE-2017-2582 - RHSA-2019:0139", vulnerabilities[0].Name)
 	assert.Equal(t, "https://access.redhat.com/security/cve/CVE-2017-2582", vulnerabilities[0].Link)
 	assert.Equal(t, database.MediumSeverity, vulnerabilities[0].Severity)
-	assert.Equal(t, "RHSA-2019:0139 - Red Hat JBoss Enterprise Application Platform is a platform for Java applications based on the JBoss Application Server.\n\nThis release serves as a replacement for Red Hat JBoss Enterprise Application Platform 7.1, and includes bug fixes and enhancements. Refer to the Red Hat JBoss Enterprise Application Platform 7.2.0 Release Notes for information on the most significant bug fixes and enhancements included in this release.\n\nSecurity Fix(es):\n\n* picketlink: SAML request parser replaces special strings with system properties (CVE-2017-2582)\n\nFor more details about the security issue(s), including the impact, a CVSS\nscore, and other related information, refer to the CVE page(s) listed in\nthe References section.\n\nThe CVE-2017-2582 issue was discovered by Hynek Mlnarik (Red Hat).", vulnerabilities[0].Description)
+	assert.Equal(t, "Red Hat JBoss Enterprise Application Platform is a platform for Java applications based on the JBoss Application Server.\n\nThis release serves as a replacement for Red Hat JBoss Enterprise Application Platform 7.1, and includes bug fixes and enhancements. Refer to the Red Hat JBoss Enterprise Application Platform 7.2.0 Release Notes for information on the most significant bug fixes and enhancements included in this release.\n\nSecurity Fix(es):\n\n* picketlink: SAML request parser replaces special strings with system properties (CVE-2017-2582)\n\nFor more details about the security issue(s), including the impact, a CVSS\nscore, and other related information, refer to the CVE page(s) listed in\nthe References section.\n\nThe CVE-2017-2582 issue was discovered by Hynek Mlnarik (Red Hat).", vulnerabilities[0].Description)
 
 	expectedFeatures := []database.AffectedFeature{
 		{

--- a/pkg/brew/brew.go
+++ b/pkg/brew/brew.go
@@ -1,3 +1,17 @@
+// Copyright 2019 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package brew
 
 import (

--- a/pkg/brew/datatypes.go
+++ b/pkg/brew/datatypes.go
@@ -1,3 +1,17 @@
+// Copyright 2019 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package brew
 
 type BuildInfo struct {


### PR DESCRIPTION
When CVE is attached to multiple advisories Clair merge them together.
This can lead to situation when affected packages will be assigned to wrong CVE.

This commit adds advisory name to CVE name to do not merge same CVEs 
with different advisory.
